### PR TITLE
Update runtime dependency for rest-client

### DIFF
--- a/telegramAPI.gemspec
+++ b/telegramAPI.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.date	= '2016-12-30'
   s.summary	= "Telegram API Wrapper for Bots"
   s.description	= "A lightweight wrapper in Ruby for Telegram API Bots"
-  s.add_runtime_dependency 'rest-client', '~> 1.7', '>=1.7.3'
+  s.add_runtime_dependency 'rest-client', '~> 2.0', '>= 2.0.2'
   s.authors	= ["Benedetto Nespoli"]
   s.email	= 'benedetto.nespoli@gmail.com'
   s.files	= ["lib/telegramAPI.rb", "README.md"]


### PR DESCRIPTION
Fixed rest-client erros "KeyError: key not found: :ciphers" which was fixed in https://github.com/rest-client/rest-client/pull/573