### PR TITLE
Not parse_hash options on sendMessage method

### DIFF
--- a/lib/telegramAPI.rb
+++ b/lib/telegramAPI.rb
@@ -50,7 +50,7 @@ class TelegramAPI
     if options.has_key?"reply_markup" then
       options["reply_markup"]=options["reply_markup"].to_json
     end
-    self.query("sendMessage", {:chat_id=>to.to_s, :text=>text}.merge(parse_hash(options)))
+    self.query("sendMessage", {:chat_id=>to.to_s, :text=>text}.merge(options))
   end
 
   def forwardMessage to, from, msg


### PR DESCRIPTION
Method parse_hash encoded URI, markup keyboard options returned 400 error from telegram bot API, not a valid JSON.
See https://github.com/bennesp/telegramAPI/issues/6