### PR TITLE
Get rid of obsolete URI::encode calls in favor of URI::encode_www_form

### DIFF
--- a/lib/telegramAPI.rb
+++ b/lib/telegramAPI.rb
@@ -19,7 +19,7 @@ class TelegramAPI
   def parse_hash hash
     ret = {}
     hash.map do |k,v|
-      ret[k]=URI::encode(v.to_s.gsub("\\\"", "\""))
+      ret[k]=URI::encode_www_form([v.to_s.gsub("\\\"", "\"")])
     end
     return ret
   end
@@ -35,7 +35,7 @@ class TelegramAPI
   end
   
   def setWebhook url
-    self.query("setWebhook", {"url"=>URI::encode(url)})
+    self.query("setWebhook", {"url"=>URI::encode_www_form([url])})
   end
 
   def getUpdates options={"timeout"=>0, "limit"=>100}

--- a/lib/telegramAPI.rb
+++ b/lib/telegramAPI.rb
@@ -31,7 +31,8 @@ class TelegramAPI
   end
 
   def post api, name, path, to, options={}
-    JSON.parse(RestClient.post(@@core+@token+api, {name=>File.new(path,'rb'), :chat_id=>to.to_s}.merge(parse_hash(options))).body)["result"]
+    file = path.start_with?('http') ? path : File.new(path,'rb')
+    JSON.parse(RestClient.post(@@core+@token+api, {name=>file, :chat_id=>to.to_s}.merge(parse_hash(options))).body)["result"]
   end
   
   def setWebhook url


### PR DESCRIPTION
When using Ruby >= 2.7.2, a
```
/app/vendor/bundle/ruby/2.7.0/gems/telegramAPI-1.4.2/lib/telegramAPI.rb:22: warning: URI.escape is obsolete
```
message gets triggered.

This should solve the issue.

Source: https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string